### PR TITLE
auth added to import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+config.ts

--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -34,6 +34,9 @@ export default function CSVFileImport({ url, title }: CSVFileImportProps) {
         params: {
           name: encodeURIComponent(file.name),
         },
+        headers: {
+          Authorization: `Basic ${localStorage.getItem("authorization_token")}`,
+        },
       });
       console.log("File to upload: ", file.name);
       console.log("Uploading to: ", response.data.url);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
 import { theme } from "~/theme";
-
+import { CONFIG } from "./config";
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: { refetchOnWindowFocus: false, retry: false, staleTime: Infinity },
@@ -18,7 +18,7 @@ if (import.meta.env.DEV) {
   const { worker } = await import("./mocks/browser");
   worker.start({ onUnhandledRequest: "bypass" });
 }
-
+localStorage.setItem('authorization_token',window.btoa(CONFIG.REACT_APP_AUTH_TOKEN));
 const container = document.getElementById("app");
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const root = createRoot(container!);


### PR DESCRIPTION
https://d2pmu4inmf6b5k.cloudfront.net/


1 - authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
3 - Import Service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
5 - Client application is updated to send "Authorization: Basic authorization_token" header on import. Client should get authorization_token value from browser 